### PR TITLE
Fix Shell 48 paint_to_content signature, a disposed-actor crash, and spurious allocate warnings

### DIFF
--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/dockManager.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/dockManager.js
@@ -319,6 +319,8 @@ export class DashManager {
     _syncGeometry() {
         if (!this.bgActor || !this.targetActor || !this.targetActor.mapped)
             return;
+        if (!this.bgActor.get_stage())
+            return; // detached during teardown - see uiManager._syncGeometry
         let sourceActor = this.targetActor;
         let children = this.targetActor.get_children();
         for (let i = 0; i < children.length; i++) {

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/notificationManager.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/notificationManager.js
@@ -299,6 +299,8 @@ export class NotificationManager {
     _syncGeometry() {
         if (!this.bgActor || !this.currentBanner)
             return;
+        if (!this.bgActor.get_stage())
+            return; // detached during teardown - see uiManager._syncGeometry
         let [w, h] = this.currentBanner.get_size();
         let [absX, absY] = this.currentBanner.get_transformed_position();
         if (Number.isNaN(absX) || Number.isNaN(absY))
@@ -585,6 +587,23 @@ export class NotificationManager {
             GLib.source_remove(actor._colorTweenId);
             actor._colorTweenId = undefined;
         }
+        // Belt-and-suspenders for a real crash: the notification banner (and
+        // its text/icon actors) can be destroyed by the shell at any point
+        // mid-tween - e.g. the notification auto-expires or is dismissed
+        // while the 380ms fade is still running. `Object.keys(actor).length
+        // === 0` does not reliably detect a disposed GObject, so the 16ms
+        // timeout kept firing into a dead actor and crashing repeatedly
+        // (seen as a GJS backtrace at this file's set_style call). Stopping
+        // the source from the actor's own 'destroy' signal removes it at the
+        // moment of disposal, so there is no later tick left to crash on.
+        if (!actor._colorTweenDestroyId) {
+            actor._colorTweenDestroyId = actor.connect('destroy', () => {
+                if (actor._colorTweenId) {
+                    GLib.source_remove(actor._colorTweenId);
+                    actor._colorTweenId = undefined;
+                }
+            });
+        }
         let themeNode = actor.get_theme_node();
         let startColor = themeNode.get_foreground_color();
         let targetRgb = this._hexToRgb(targetHexColor);
@@ -594,23 +613,31 @@ export class NotificationManager {
             return;
         }
         actor._colorTweenId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 16, () => {
-            if (!actor || Object.keys(actor).length === 0)
-                return GLib.SOURCE_REMOVE;
-            let currentTime = GLib.get_monotonic_time();
-            let elapsedMs = (currentTime - startTime) / 1000;
-            let progress = Math.min(elapsedMs / durationMs, 1.0);
-            let ease = progress < 0.5
-                ? 2 * progress * progress
-                : 1 - Math.pow(-2 * progress + 2, 2) / 2;
-            let r = Math.round(startColor.red + (targetRgb.r - startColor.red) * ease);
-            let g = Math.round(startColor.green + (targetRgb.g - startColor.green) * ease);
-            let b = Math.round(startColor.blue + (targetRgb.b - startColor.blue) * ease);
-            actor.set_style(`color: ${this._rgbToHex(r, g, b)}; -st-icon-foreground-color: ${this._rgbToHex(r, g, b)};`);
-            if (progress >= 1.0) {
+            // Retained as a second line of defense in case some destruction
+            // path doesn't emit 'destroy' before this tick is already queued.
+            try {
+                if (!actor || Object.keys(actor).length === 0)
+                    return GLib.SOURCE_REMOVE;
+                let currentTime = GLib.get_monotonic_time();
+                let elapsedMs = (currentTime - startTime) / 1000;
+                let progress = Math.min(elapsedMs / durationMs, 1.0);
+                let ease = progress < 0.5
+                    ? 2 * progress * progress
+                    : 1 - Math.pow(-2 * progress + 2, 2) / 2;
+                let r = Math.round(startColor.red + (targetRgb.r - startColor.red) * ease);
+                let g = Math.round(startColor.green + (targetRgb.g - startColor.green) * ease);
+                let b = Math.round(startColor.blue + (targetRgb.b - startColor.blue) * ease);
+                actor.set_style(`color: ${this._rgbToHex(r, g, b)}; -st-icon-foreground-color: ${this._rgbToHex(r, g, b)};`);
+                if (progress >= 1.0) {
+                    actor._colorTweenId = undefined;
+                    return GLib.SOURCE_REMOVE;
+                }
+                return GLib.SOURCE_CONTINUE;
+            }
+            catch (e) {
                 actor._colorTweenId = undefined;
                 return GLib.SOURCE_REMOVE;
             }
-            return GLib.SOURCE_CONTINUE;
         });
     }
     _hasStyleClass(actor, className) {

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/quickSettingsManager.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/quickSettingsManager.js
@@ -448,6 +448,8 @@ export class QuickSettingsManager {
     // Full-screen FBO approach: bgActor covers the entire monitor, shader is told
     // where the menu lives within that FBO via setGlassGeometry().
     _syncGeometry() {
+        if (this.bgActor && !this.bgActor.get_stage())
+            return; // detached during teardown - see uiManager._syncGeometry
         if (!this.bgActor || !this.targetActor || !this.targetActor.mapped) {
             if (this.bgActor && this.bgActor.visible)
                 this.bgActor.hide();

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/uiManager.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/uiManager.js
@@ -486,6 +486,16 @@ export class UIManager {
             }
             return;
         }
+        // A queued sync (timer / signal / later) can still fire after bgActor
+        // has been unparented or destroyed during teardown. Resizing or
+        // repositioning a detached actor queues a relayout on something that
+        // is no longer under the stage, which Mutter reports as
+        // "Spurious clutter_actor_allocate called for actor
+        //  liquid-glass-bg-actor ... which isn't a descendent of the stage!".
+        // get_stage() is null exactly in that state, so bail before touching
+        // geometry.
+        if (!this.bgActor.get_stage())
+            return;
         if (!this.bgActor.visible) {
             this.bgActor.show();
         }

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/utils.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/utils.js
@@ -11,6 +11,18 @@ import Cogl from 'gi://Cogl';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import Mtk from 'gi://Mtk';
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+/**
+ * Major GNOME Shell version, used to pick between API signatures that changed
+ * across releases (see SelfExcludingSnapshotCapture._captureOnce). Falls back
+ * to 49 - the version this extension's metadata targets - if the version
+ * string is ever missing or unparseable, so a bad probe degrades to the
+ * newer/expected API rather than silently selecting a legacy path.
+ */
+const SHELL_MAJOR = (() => {
+    const v = parseInt(String(Config?.PACKAGE_VERSION ?? '').split('.')[0], 10);
+    return Number.isFinite(v) ? v : 49;
+})();
 /**
  * Captures a small rectangle of the screen (the panel area) into a
  * `Clutter.Content`, for use as the "blurred panel" backdrop inside the
@@ -123,11 +135,26 @@ export class SelfExcludingSnapshotCapture {
             }
             const rect = new Mtk.Rectangle({ x: Math.round(x), y: Math.round(y), width: Math.round(w), height: Math.round(h) });
             const scale = 1; // TODO: honor per-monitor resource scale if this is ever used on HiDPI setups.
-            // Signature is (rect, scale, color_state, paint_flags); color_state
-            // of null uses the default color space. NO_CURSORS excludes the
-            // mouse pointer sprite from the snapshot (see class doc comment).
+            // clutter_stage_paint_to_content()'s signature is version
+            // dependent, so the argument list has to be chosen at runtime:
+            //
+            //   Mutter 48:  (rect, scale, paint_flags, **error)
+            //   Mutter 49+: (rect, scale, color_state, paint_flags, **error)
+            //
+            // (The trailing GError** is consumed by GJS and is invisible to
+            // JS callers.) Verified against the Debian mutter 48.7-0+deb13u1
+            // source, clutter/clutter/clutter-stage.c.
+            //
+            // Passing the 49+ form on 48 trips GJS's "Too many arguments"
+            // path: the call still runs, but paint_flags never reaches the
+            // real function, so NO_CURSORS is silently lost and the mouse
+            // pointer gets baked into the snapshot. Passing the 48 form on
+            // 49+ would instead land paint_flags in the color_state slot.
+            // NO_CURSORS excludes the pointer sprite (see class doc comment).
             const paintFlags = Clutter.PaintFlag?.NO_CURSORS ?? 0;
-            const content = this._stage.paint_to_content?.(rect, scale, null, paintFlags);
+            const content = SHELL_MAJOR >= 49
+                ? this._stage.paint_to_content?.(rect, scale, null, paintFlags)
+                : this._stage.paint_to_content?.(rect, scale, paintFlags);
             if (content)
                 this._content = content;
         }

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/dockManager.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/dockManager.ts
@@ -378,6 +378,8 @@ export class DashManager {
 
   _syncGeometry() {
     if (!this.bgActor || !this.targetActor || !this.targetActor.mapped) return;
+    // detached during teardown - see uiManager._syncGeometry
+    if (!this.bgActor.get_stage()) return;
 
     let sourceActor = this.targetActor;
     let children = this.targetActor.get_children() as St.Widget[];

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/notificationManager.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/notificationManager.ts
@@ -22,6 +22,7 @@ const HIDE_SAFETY_MARGIN = 7;
 
 interface CustomBannerActor extends St.Widget {
   _colorTweenId?: number;
+  _colorTweenDestroyId?: number;
   _currentTargetColor?: string;
 }
 
@@ -364,6 +365,8 @@ export class NotificationManager {
   // assumptions are satisfied (all actors cover the entire monitor).
   _syncGeometry() {
     if (!this.bgActor || !this.currentBanner) return;
+    // detached during teardown - see uiManager._syncGeometry
+    if (!this.bgActor.get_stage()) return;
 
     let [w, h] = this.currentBanner.get_size();
     let [absX, absY] = this.currentBanner.get_transformed_position();
@@ -688,6 +691,23 @@ export class NotificationManager {
       actor._colorTweenId = undefined;
     }
 
+    // Belt-and-suspenders for a real crash: the notification banner (and its
+    // text/icon actors) can be destroyed by the shell at any point mid-tween
+    // - e.g. the notification auto-expires or is dismissed while the 380ms
+    // fade is still running. `Object.keys(actor).length === 0` does not
+    // reliably detect a disposed GObject, so the 16ms timeout kept firing
+    // into a dead actor and crashing repeatedly. Stopping the source from the
+    // actor's own 'destroy' signal removes it at the moment of disposal, so
+    // there is no later tick left to crash on.
+    if (!actor._colorTweenDestroyId) {
+      actor._colorTweenDestroyId = actor.connect('destroy', () => {
+        if (actor._colorTweenId) {
+          GLib.source_remove(actor._colorTweenId);
+          actor._colorTweenId = undefined;
+        }
+      });
+    }
+
     let themeNode = actor.get_theme_node();
     let startColor = themeNode.get_foreground_color();
     let targetRgb = this._hexToRgb(targetHexColor);
@@ -699,25 +719,32 @@ export class NotificationManager {
     }
 
     actor._colorTweenId = GLib.timeout_add(GLib.PRIORITY_DEFAULT, 16, () => {
-      if (!actor || Object.keys(actor).length === 0) return GLib.SOURCE_REMOVE;
+      // Retained as a second line of defense in case some destruction path
+      // doesn't emit 'destroy' before this tick is already queued.
+      try {
+        if (!actor || Object.keys(actor).length === 0) return GLib.SOURCE_REMOVE;
 
-      let currentTime = GLib.get_monotonic_time();
-      let elapsedMs = (currentTime - startTime) / 1000;
-      let progress = Math.min(elapsedMs / durationMs, 1.0);
-      let ease = progress < 0.5
-        ? 2 * progress * progress
-        : 1 - Math.pow(-2 * progress + 2, 2) / 2;
+        let currentTime = GLib.get_monotonic_time();
+        let elapsedMs = (currentTime - startTime) / 1000;
+        let progress = Math.min(elapsedMs / durationMs, 1.0);
+        let ease = progress < 0.5
+          ? 2 * progress * progress
+          : 1 - Math.pow(-2 * progress + 2, 2) / 2;
 
-      let r = Math.round(startColor.red + (targetRgb.r - startColor.red) * ease);
-      let g = Math.round(startColor.green + (targetRgb.g - startColor.green) * ease);
-      let b = Math.round(startColor.blue + (targetRgb.b - startColor.blue) * ease);
-      actor.set_style(`color: ${this._rgbToHex(r, g, b)}; -st-icon-foreground-color: ${this._rgbToHex(r, g, b)};`);
+        let r = Math.round(startColor.red + (targetRgb.r - startColor.red) * ease);
+        let g = Math.round(startColor.green + (targetRgb.g - startColor.green) * ease);
+        let b = Math.round(startColor.blue + (targetRgb.b - startColor.blue) * ease);
+        actor.set_style(`color: ${this._rgbToHex(r, g, b)}; -st-icon-foreground-color: ${this._rgbToHex(r, g, b)};`);
 
-      if (progress >= 1.0) {
+        if (progress >= 1.0) {
+          actor._colorTweenId = undefined;
+          return GLib.SOURCE_REMOVE;
+        }
+        return GLib.SOURCE_CONTINUE;
+      } catch (e) {
         actor._colorTweenId = undefined;
         return GLib.SOURCE_REMOVE;
       }
-      return GLib.SOURCE_CONTINUE;
     });
   }
 

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/quickSettingsManager.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/quickSettingsManager.ts
@@ -529,6 +529,9 @@ export class QuickSettingsManager {
   // Full-screen FBO approach: bgActor covers the entire monitor, shader is told
   // where the menu lives within that FBO via setGlassGeometry().
   _syncGeometry() {
+    // detached during teardown - see uiManager._syncGeometry
+    if (this.bgActor && !this.bgActor.get_stage()) return;
+
     if (!this.bgActor || !this.targetActor || !this.targetActor.mapped) {
       if (this.bgActor && this.bgActor.visible) this.bgActor.hide();
       return;

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/uiManager.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/uiManager.ts
@@ -577,6 +577,15 @@ export class UIManager {
 
   // Calculates and synchronizes the position/size of the glass background every frame
   _syncGeometry() {
+    // A queued sync (timer / signal / later) can still fire after bgActor has
+    // been unparented or destroyed during teardown. Resizing or repositioning
+    // a detached actor queues a relayout on something that is no longer under
+    // the stage, which Mutter reports as "Spurious clutter_actor_allocate
+    // called for actor liquid-glass-bg-actor ... which isn't a descendent of
+    // the stage!". get_stage() is null exactly in that state, so bail before
+    // touching geometry.
+    if (this.bgActor && !this.bgActor.get_stage()) return;
+
     if (!this.bgActor || !this.targetActor || !this.targetActor.mapped) {
       if (this.bgActor && this.bgActor.visible) {
         this.bgActor.hide();

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/utils.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/utils.ts
@@ -11,6 +11,20 @@ import Cogl from 'gi://Cogl';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import Mtk from 'gi://Mtk';
+// @ts-ignore - no typings ship for the Shell's internal config module
+import * as Config from 'resource:///org/gnome/shell/misc/config.js';
+
+/**
+ * Major GNOME Shell version, used to pick between API signatures that changed
+ * across releases (see SelfExcludingSnapshotCapture._captureOnce). Falls back
+ * to 49 - the version this extension's metadata targets - if the version
+ * string is ever missing or unparseable, so a bad probe degrades to the
+ * newer/expected API rather than silently selecting a legacy path.
+ */
+const SHELL_MAJOR: number = (() => {
+  const v = parseInt(String((Config as any)?.PACKAGE_VERSION ?? '').split('.')[0], 10);
+  return Number.isFinite(v) ? v : 49;
+})();
 
 
 /**
@@ -124,11 +138,26 @@ export class SelfExcludingSnapshotCapture {
       const rect = new Mtk.Rectangle({ x: Math.round(x), y: Math.round(y), width: Math.round(w), height: Math.round(h) });
       const scale = 1; // TODO: honor per-monitor resource scale if this is ever used on HiDPI setups.
 
-      // Signature is (rect, scale, color_state, paint_flags); color_state
-      // of null uses the default color space. NO_CURSORS excludes the
-      // mouse pointer sprite from the snapshot (see class doc comment).
+      // clutter_stage_paint_to_content()'s signature is version dependent, so
+      // the argument list has to be chosen at runtime:
+      //
+      //   Mutter 48:  (rect, scale, paint_flags, **error)
+      //   Mutter 49+: (rect, scale, color_state, paint_flags, **error)
+      //
+      // (The trailing GError** is consumed by GJS and is invisible to JS
+      // callers.) Verified against the Debian mutter 48.7-0+deb13u1 source,
+      // clutter/clutter/clutter-stage.c.
+      //
+      // Passing the 49+ form on 48 trips GJS's "Too many arguments" path: the
+      // call still runs, but paint_flags never reaches the real function, so
+      // NO_CURSORS is silently lost and the mouse pointer gets baked into the
+      // snapshot. Passing the 48 form on 49+ would instead land paint_flags in
+      // the color_state slot. NO_CURSORS excludes the pointer sprite (see
+      // class doc comment).
       const paintFlags = (Clutter as any).PaintFlag?.NO_CURSORS ?? 0;
-      const content = (this._stage as any).paint_to_content?.(rect, scale, null, paintFlags);
+      const content = SHELL_MAJOR >= 49
+        ? (this._stage as any).paint_to_content?.(rect, scale, null, paintFlags)
+        : (this._stage as any).paint_to_content?.(rect, scale, paintFlags);
       if (content) this._content = content;
     } catch (e) {
     } finally {


### PR DESCRIPTION
Three independent bug fixes found while running this extension on GNOME Shell 48.7 / Mutter 48.7 (Debian 13). Each is a separate commit and they can be taken independently.

No visual/design changes are included — this is bug fixes only.

## 1. `paint_to_content()` signature is version dependent

`clutter_stage_paint_to_content()` gained a `color_state` parameter after Mutter 48:

| Version | Signature |
|---|---|
| Mutter 48 | `(rect, scale, paint_flags, **error)` |
| Mutter 49+ | `(rect, scale, color_state, paint_flags, **error)` |

The call site passed the 49+ form unconditionally, so on Mutter 48 it logs:

```
JS WARNING: [.../dist/utils.js 130]: Too many arguments to method
Clutter.Stage.paint_to_content: expected 3, got 4
```

The call still returns content, so it fails quietly — but `paint_flags` never reaches the real function, meaning `Clutter.PaintFlag.NO_CURSORS` is dropped and the mouse pointer sprite gets baked into the snapshot used as the glass backdrop.

Verified against the Debian `mutter 48.7-0+deb13u1` source, `clutter/clutter/clutter-stage.c:2842`.

Rather than hardcoding either form, the argument list is now picked at runtime from `Config.PACKAGE_VERSION`, so one build stays correct on 48 and on 49/50. If the version can't be parsed it falls back to the 49+ form (the version this extension's metadata targets).

## 2. Adaptive-text colour tween crashes on destroyed actors

`_animateActorColor()` runs a 380ms fade on a 16ms `GLib.timeout_add`, calling `actor.set_style()` each tick. If the banner is dismissed or expires mid-fade, the actor is disposed while the timer is still live, and every subsequent tick throws:

```
JS ERROR: ... notificationManager.js:608
```

The existing `Object.keys(actor).length === 0` guard doesn't detect a disposed GObject, so it never caught this.

Fixed by removing the source from the actor's own `destroy` signal, which fires at the moment of disposal. The original guard plus a `try`/`catch` are kept as a second line of defence for any destruction path that doesn't emit `destroy` before an already-queued tick.

## 3. Spurious `clutter_actor_allocate` on a detached `bgActor`

A queued `_syncGeometry()` can still run after `bgActor` has been unparented during teardown, calling `set_position()`/`set_size()` on a detached actor. That queues a relayout on something no longer under the stage, and Mutter logs this repeatedly during normal use:

```
Spurious clutter_actor_allocate called for actor
<...>/liquid-glass-bg-actor [Gjs_dist_utils_UnpickableActor]
which isn't a descendent of the stage!
```

The guards checked `targetActor`/`currentBanner` but never whether `bgActor` itself was still on the stage. `get_stage()` returns null in exactly that state.

Applied to all four managers that own a `bgActor`: `uiManager`, `quickSettingsManager`, `dockManager`, `notificationManager`.

## Notes

- Both `dist/` and `src/` are updated so a `tsc` rebuild won't revert the fixes.
- Tested on GNOME Shell 48.7, Wayland, hybrid Intel + NVIDIA (proprietary 550.163.01).
- I can only directly verify the 48 path; the 49+ path is preserved as the existing behaviour, gated on the version check.

🤖 Generated with [Claude Code](https://claude.com/claude-code)