### PR TITLE
[Window Effect] Fix infinite recursion on corner overlay when another gnome extension, PaperWM, is enabled

### DIFF
--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/applicationManager.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/applicationManager.js
@@ -5,7 +5,7 @@ import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { LiquidEffect } from './liquidEffect.js';
 import GLib from 'gi://GLib';
-import { UnpickableClone, UnpickableActor, InverseCornerEffect, getWindowActors, isActorValid } from './utils.js';
+import { UnpickableClone, UnpickableActor, InverseCornerEffect, getWindowActors, isActorValid, createWallpaperSampler, refreshWallpaperSampler } from './utils.js';
 // Padding to allow the shader to draw effects (like refraction and blur) outside the actor's strict bounds.
 const SHADER_PADDING = 10;
 // Inward padding for corner rounding
@@ -227,6 +227,33 @@ export class ApplicationManager {
     _cornerOverlayInset() {
         return SHADER_PADDING;
     }
+    // ─── [Debug] helpers ──────────────────────────────────────────────────────
+    _winTitle(state) {
+        try {
+            const meta = state.windowActor?.get_meta_window?.();
+            return meta?.get_title?.() ?? state.windowActor?.get_name?.() ?? '?';
+        }
+        catch (e) {
+            return '?';
+        }
+    }
+    _winTitleOfActor(windowActor) {
+        try {
+            const meta = windowActor?.get_meta_window?.();
+            return meta?.get_title?.() ?? windowActor?.get_name?.() ?? '?';
+        }
+        catch (e) {
+            return '?';
+        }
+    }
+    // _syncState runs every frame; log only when the outcome changes so
+    // journalctl isn't flooded at 60fps.
+    _debugSync(state, msg) {
+        if (state._lastSyncLog === msg)
+            return;
+        state._lastSyncLog = msg;
+        this._logger.log(`[Liquid Glass][Debug] _syncState["${this._winTitle(state)}"]: ${msg}`);
+    }
     _startFrameSync() {
         if (this._frameSyncId === 0)
             this._frameTick();
@@ -266,22 +293,25 @@ export class ApplicationManager {
         let parent = windowActor.get_parent();
         if (!parent)
             return;
+        this._logger.log(`[Liquid Glass][Debug] _setupWindow: setting up glass for window "${this._winTitleOfActor(windowActor)}", ` +
+            `surface="${surfaceActor.get_name?.() ?? surfaceActor.constructor.name}", parent="${parent.get_name?.() ?? parent.constructor.name}"`);
         // Store the surface's original opacity and dial it down so the glass behind
         // it is actually visible; restored in _cleanupState when the effect is removed.
         let originalOpacity = surfaceActor.opacity;
         surfaceActor.opacity = Math.round(this._getContentOpacity() * 255);
+        this._logger.log(`[Liquid Glass][Debug] _setupWindow: surface opacity ${originalOpacity} -> ${surfaceActor.opacity}`);
         let baseActor = new St.Widget({
             style_class: 'liquid-glass-base-actor',
             reactive: false,
             clip_to_allocation: true,
-            visible: true,
+            visible: false,
         });
         windowActor.insert_child_below(baseActor, surfaceActor);
         let bgActor = new St.Widget({
             style_class: 'liquid-glass-bg-actor',
             reactive: false,
             clip_to_allocation: false,
-            visible: true,
+            visible: false,
         });
         windowActor.insert_child_above(bgActor, baseActor);
         // Both actors sit entirely behind surfaceActor (the window's own content),
@@ -303,18 +333,18 @@ export class ApplicationManager {
         bgActor.add_child(clipBox);
         // Size the clones to cover the full monitor so the wallpaper fills correctly.
         let monitor = Main.layoutManager.primaryMonitor;
-        let baseClone = new UnpickableClone({
-            source: Main.layoutManager._backgroundGroup,
-        });
+        // Wallpaper-only sampler: cloning _backgroundGroup as a whole is unsafe
+        // with PaperWM active (PaperWM nests its window clones inside it, which
+        // closes an infinite paint-recursion through the glass chrome →
+        // _backgroundGroup → PaperWM window clone → window chrome → ...).
+        let baseClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
         if (monitor) {
             baseClone.set_size(monitor.width, monitor.height);
         }
         baseActor.add_child(baseClone);
         let baseWindowsContainer = new Clutter.Actor();
         baseActor.add_child(baseWindowsContainer);
-        let bgClone = new UnpickableClone({
-            source: Main.layoutManager._backgroundGroup,
-        });
+        let bgClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
         if (monitor) {
             bgClone.set_size(monitor.width, monitor.height);
         }
@@ -360,6 +390,7 @@ export class ApplicationManager {
         let cornerOverlay = new UnpickableActor({
             clip_to_allocation: true,
             reactive: false,
+            visible: false,
         });
         let cornerOverlayClone = new UnpickableClone({ source: baseActor });
         cornerOverlay.add_child(cornerOverlayClone);
@@ -388,6 +419,9 @@ export class ApplicationManager {
             originalOpacity,
         };
         this._states.set(windowActor, state);
+        this._logger.log(`[Liquid Glass][Debug] _setupWindow: state registered for "${this._winTitleOfActor(windowActor)}", ` +
+            `bgActor="${state.bgActor.get_name?.() ?? state.bgActor.constructor.name}", ` +
+            `baseActor="${state.baseActor.get_name?.() ?? state.baseActor.constructor.name}"`);
         this._rebuildWindowClones(state);
         // Immediate sync connections for resize/move using allocation property
         state.signals.push({
@@ -413,6 +447,7 @@ export class ApplicationManager {
         // Use a later to ensure the initial sync happens after actors are properly added to stage
         global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
             if (this._states.has(windowActor)) {
+                this._logger.log(`[Liquid Glass][Debug] _setupWindow: IDLE initial sync for "${this._winTitle(state)}"`);
                 this._syncState(state);
             }
             return false;
@@ -453,26 +488,39 @@ export class ApplicationManager {
             state.baseWindowsContainer.add_child(baseClone);
             state.baseClones.set(actor, baseClone);
         }
+        this._logger.log(`[Liquid Glass][Debug] _rebuildWindowClones["${this._winTitle(state)}"]: ` +
+            `${state.clones.size} blurred clones, ${state.baseClones.size} base clones`);
     }
     _syncState(state) {
         let actor = state.windowActor;
         if (!actor || !actor.get_stage() || !actor.mapped) {
+            this._debugSync(state, 'window not mapped / off-stage; glass hidden');
             state.bgActor.visible = false;
             state.baseActor.visible = false;
             state.cornerOverlay.visible = false;
             return;
         }
         if (!actor.has_allocation()) {
+            this._debugSync(state, 'no allocation yet; glass hidden');
+            state.bgActor.visible = false;
+            state.baseActor.visible = false;
+            state.cornerOverlay.visible = false;
             return;
         }
         const metaWin = actor.get_meta_window();
-        if (!metaWin)
+        if (!metaWin) {
+            this._debugSync(state, 'no meta-window; glass hidden');
+            state.bgActor.visible = false;
+            state.baseActor.visible = false;
+            state.cornerOverlay.visible = false;
             return;
+        }
         // PERFORMANCE: Only sync windows on the current active workspace.
         const workspaceManager = global.workspace_manager;
         const activeWorkspace = workspaceManager.get_active_workspace();
         const winWorkspace = metaWin.get_workspace();
         if (winWorkspace && winWorkspace !== activeWorkspace) {
+            this._debugSync(state, 'not on active workspace; glass hidden');
             if (state.bgActor.visible)
                 state.bgActor.visible = false;
             if (state.baseActor.visible)
@@ -484,6 +532,7 @@ export class ApplicationManager {
         const rect = metaWin.get_frame_rect();
         const bufferRect = metaWin.get_buffer_rect();
         if (!rect || !bufferRect || rect.width <= 0 || rect.height <= 0) {
+            this._debugSync(state, `invalid frame rect (${rect?.x},${rect?.y} ${rect?.width}x${rect?.height}); glass hidden`);
             if (state.bgActor.visible)
                 state.bgActor.visible = false;
             if (state.baseActor.visible)
@@ -492,10 +541,19 @@ export class ApplicationManager {
                 state.cornerOverlay.visible = false;
             return;
         }
+        this._debugSync(state, `showing glass: frame=(${rect.x},${rect.y} ${rect.width}x${rect.height}) ` +
+            `buffer=(${bufferRect.x},${bufferRect.y} ${bufferRect.width}x${bufferRect.height}) ` +
+            `bg=${rect.width + (SHADER_PADDING * 2)}x${rect.height + (SHADER_PADDING * 2)} ` +
+            `base=${rect.width + (SHADER_PADDING * 2)}x${rect.height + (SHADER_PADDING * 2)} ` +
+            `clones=${state.clones.size}/${state.baseClones.size} surfaceOpacity=${state.surfaceActor.opacity}`);
         if (!state.bgActor.visible)
             state.bgActor.visible = true;
         if (!state.baseActor.visible)
             state.baseActor.visible = true;
+        // Rebuild the wallpaper samplers in place if the wallpaper actors were
+        // swapped (wallpaper/monitor changes). Cheap identity check per frame.
+        refreshWallpaperSampler(state.bgClone);
+        refreshWallpaperSampler(state.baseClone);
         // Local offset of the visible frame within the window actor's full buffer.
         const frameLocalX = rect.x - bufferRect.x;
         const frameLocalY = rect.y - bufferRect.y;
@@ -588,6 +646,8 @@ export class ApplicationManager {
     _cleanupState(state) {
         if (!state)
             return;
+        this._logger.log(`[Liquid Glass][Debug] _cleanupState["${this._winTitle(state)}"]: removing glass, ` +
+            `restoring surface opacity ${state.surfaceActor?.opacity} -> ${state.originalOpacity}`);
         // Restore the original opacity of the window's own content layer.
         // Uses the cached surfaceActor reference (see WindowState) rather than
         // windowActor.get_first_child(), which no longer points at the real

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/liquidEffect.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/liquidEffect.js
@@ -101,6 +101,8 @@ export const LiquidEffect = GObject.registerClass({
         this._diagCompositedPaintCount = 0;
         this._diagLastPaintLogAt = 0;
         this._diagFirstPaintLogged = false;
+        this._lastPaintSig = null;
+        this._lastCropLog = null;
         this._extensionPath = extensionPath;
         this._settings = settings;
         this._logger = logger;
@@ -267,6 +269,9 @@ export const LiquidEffect = GObject.registerClass({
         this._loadCompositeShader();
         // Apply any uniforms that were buffered before the pipeline existed.
         this._applyPendingUniforms();
+        this._logger?.log(`[Liquid Glass][Debug] _initPipelines: pipelines compiled ` +
+            `(composite=${!!this._compositePipeline}, down=${!!this._downsamplePipeline}, ` +
+            `up=${!!this._upsamplePipeline}, gaussian=${!!this._gaussianHPipeline && !!this._gaussianVPipeline})`);
     }
     /**
      * Shared helper: sets bilinear filtering and clamp-to-edge wrapping on
@@ -455,6 +460,9 @@ export const LiquidEffect = GObject.registerClass({
         }
         this._poolWidth = w;
         this._poolHeight = h;
+        this._logger?.log(`[Liquid Glass][Debug] _buildTexturePool: ${this.PASS_COUNT} passes built for ${w}x${h} ` +
+            `(top level ${this._blurTextures[0]?.get_width?.() ?? '?'}x${this._blurTextures[0]?.get_height?.() ?? '?'}, ` +
+            `textures=${this._blurTextures.length}, gaussianTemp=${this._gaussianTempTextures.length})`);
     }
     /**
      * Runs the Dual Kawase blur.
@@ -593,6 +601,11 @@ export const LiquidEffect = GObject.registerClass({
      * one if the size hasn't changed.
      */
     _ensureCropTarget(ctx, w, h) {
+        // Never create a 0-size texture: Cogl asserts width/height >= 1 and returns
+        // NULL otherwise (cogl_texture_2d_new_with_size: assertion 'width >= 1'
+        // failed), and the resulting NULL texture would crash Offscreen.new_with_texture.
+        w = Math.max(Math.round(w), 1);
+        h = Math.max(Math.round(h), 1);
         if (this._cropTexture && this._cropFbo &&
             this._cropPoolW === w && this._cropPoolH === h) {
             return true;
@@ -610,6 +623,7 @@ export const LiquidEffect = GObject.registerClass({
             this._cropFbo = fbo;
             this._cropPoolW = w;
             this._cropPoolH = h;
+            this._logger?.log(`[Liquid Glass][Debug] _ensureCropTarget: created crop texture ${w}x${h}`);
             return true;
         }
         catch (e) {
@@ -782,6 +796,22 @@ export const LiquidEffect = GObject.registerClass({
             if (Number.isFinite(ah) && ah > 0)
                 allocH = Math.round(ah);
         }
+        // [Debug] Log the per-frame paint geometry, but only when it changes so
+        // journalctl isn't flooded at 60fps.
+        {
+            let actorName = '?';
+            try {
+                actorName = (actor?.get_name?.() ?? actor?.constructor?.name ?? '?');
+            }
+            catch (e) { }
+            const paintSig = `src=${srcW}x${srcH} alloc=${allocW}x${allocH} ` +
+                `cropPool=${this._cropPoolW}x${this._cropPoolH} pool=${this._poolWidth}x${this._poolHeight} ` +
+                `blurMethod=${this._blurMethod} passCount=${this.PASS_COUNT} shadersLoaded=${this._shadersLoaded}`;
+            if (this._lastPaintSig !== paintSig) {
+                this._lastPaintSig = paintSig;
+                this._logger?.log(`[Liquid Glass][Debug] vfunc_paint_target["${actorName}"]: ${paintSig}`);
+            }
+        }
         // ── Only run the crop pass when padding is actually present ─────────────
         // (When sizes match, _cropSourceTexture just returns srcTex unchanged,
         //  so the normal-case overhead is a single size comparison.)
@@ -800,6 +830,11 @@ export const LiquidEffect = GObject.registerClass({
                 if (effectiveTex !== srcTex) {
                     effectiveW = allocW;
                     effectiveH = allocH;
+                    const cropLog = `${srcW}x${srcH}->${allocW}x${allocH}`;
+                    if (this._lastCropLog !== cropLog) {
+                        this._lastCropLog = cropLog;
+                        this._logger?.log(`[Liquid Glass][Debug] crop applied: ${cropLog}`);
+                    }
                 }
             }
             catch (e) {

--- a/liquid-glass@thinkingcoding1231.gmail.com/dist/utils.js
+++ b/liquid-glass@thinkingcoding1231.gmail.com/dist/utils.js
@@ -8,6 +8,7 @@
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 import Cogl from 'gi://Cogl';
+import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import Mtk from 'gi://Mtk';
@@ -212,6 +213,92 @@ export const UnpickableWidget = GObject.registerClass(class UnpickableWidget ext
         // No-op: never respond to picking.
     }
 });
+/**
+ * Returns an actor that renders just the wallpaper — the Meta.BackgroundActor
+ * children of `Main.layoutManager._backgroundGroup` — positioned exactly as a
+ * whole-group clone would be. Returns null if the group or its background
+ * actors are unavailable, in which case callers fall back to cloning the group.
+ *
+ * WHY NOT clone `_backgroundGroup` directly: extensions such as PaperWM
+ * reparent their window-clone trees into it (PaperWM's tiling.js does
+ * `backgroundGroup.add_child(spaceContainer)`, and `spaceContainer` holds a
+ * `Clutter.Clone` of every window actor). Cloning the group then closes an
+ * infinite paint-recursion once a Liquid Glass window is visible:
+ *
+ *     bgClone → _backgroundGroup → PaperWM window clone → window actor →
+ *     glass chrome (cornerOverlay/baseActor) → bgClone → ...
+ *
+ * Each cycle re-paints the same actors forever → stack overflow / SEGV.
+ * Sampling only the Meta.BackgroundActor children keeps the wallpaper while
+ * excluding every extension-added subtree, so the loop can never close.
+ */
+function _wallpaperBackgroundActors() {
+    const bgGroup = Main.layoutManager._backgroundGroup;
+    if (!bgGroup)
+        return [];
+    try {
+        return (bgGroup.get_children() ?? []).filter(c => c instanceof Meta.BackgroundActor);
+    }
+    catch (_) {
+        return [];
+    }
+}
+function _rebuildWallpaperSamplerClones(sampler) {
+    const wallpapers = _wallpaperBackgroundActors();
+    sampler._wallpaperSources = wallpapers;
+    try {
+        sampler.remove_all_children();
+    }
+    catch (_) {
+        return;
+    }
+    for (const wp of wallpapers) {
+        const clone = new UnpickableClone({ source: wp });
+        try {
+            clone.set_size(wp.get_width(), wp.get_height());
+        }
+        catch (_) { }
+        try {
+            sampler.add_child(clone);
+        }
+        catch (_) { }
+    }
+}
+/**
+ * Creates a wallpaper sampler sized like the background group. The returned
+ * actor is a plain container (not a Clutter.Clone), so callers keep using
+ * set_position()/set_size() exactly as they did with the old whole-group clone.
+ */
+export function createWallpaperSampler() {
+    const bgGroup = Main.layoutManager._backgroundGroup;
+    if (!bgGroup)
+        return null;
+    if (_wallpaperBackgroundActors().length === 0)
+        return null;
+    const sampler = new UnpickableActor();
+    sampler._isWallpaperSampler = true;
+    try {
+        sampler.set_size(bgGroup.get_width(), bgGroup.get_height());
+    }
+    catch (_) { }
+    _rebuildWallpaperSamplerClones(sampler);
+    return sampler;
+}
+/**
+ * Rebuilds a wallpaper sampler's clones in place if the set of wallpaper
+ * actors changed (wallpaper changes swap Meta.BackgroundActor instances).
+ * Cheap: compares the stored source list each call; rebuilds only on change.
+ * No-op for actors that were not created by createWallpaperSampler().
+ */
+export function refreshWallpaperSampler(sampler) {
+    if (!sampler || !sampler._isWallpaperSampler)
+        return;
+    const cur = sampler._wallpaperSources;
+    const wallpapers = _wallpaperBackgroundActors();
+    if (cur && cur.length === wallpapers.length && cur.every((a, i) => a === wallpapers[i]))
+        return;
+    _rebuildWallpaperSamplerClones(sampler);
+}
 /**
  * Paints a captured texture stretched to fill its own allocation, without
  * ever triggering the source actor's own paint. Used for the "read an
@@ -813,7 +900,10 @@ export class WindowCloneManager {
     constructor(container, cloneContainer = null) {
         this.container = container;
         this._windowClones = new Map();
-        this.bgClone = new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
+        // Wallpaper-only sampler: cloning _backgroundGroup as a whole is unsafe
+        // with PaperWM active (PaperWM nests window clones inside it, which
+        // closes an infinite paint-recursion through visible glass chrome).
+        this.bgClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
         this.bgClone.connect('destroy', () => { this.bgClone = null; });
         this.windowClonesContainer = new UnpickableActor();
         this.windowClonesContainer.connect('destroy', () => { this.windowClonesContainer = null; });
@@ -840,7 +930,7 @@ export class WindowCloneManager {
         if (this.windowClonesContainer) {
             this.windowClonesContainer.destroy();
         }
-        this.bgClone = new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
+        this.bgClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
         this.bgClone.connect('destroy', () => { this.bgClone = null; });
         this.windowClonesContainer = new UnpickableActor();
         this.windowClonesContainer.connect('destroy', () => { this.windowClonesContainer = null; });

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/applicationManager.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/applicationManager.ts
@@ -6,7 +6,7 @@ import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import { LiquidEffect } from './liquidEffect.js';
 import Gio from 'gi://Gio';
 import GLib from 'gi://GLib';
-import { UnpickableClone, UnpickableActor, InverseCornerEffect, getWindowActors, isActorValid } from './utils.js';
+import { UnpickableClone, UnpickableActor, InverseCornerEffect, getWindowActors, isActorValid, createWallpaperSampler, refreshWallpaperSampler } from './utils.js';
 
 import { Logger } from './logger.js';
 
@@ -24,13 +24,13 @@ interface WindowState {
   surfaceActor: Clutter.Actor;
   bgActor: St.Widget;
   clipBox: St.Widget;
-  bgClone: InstanceType<typeof UnpickableClone>;
+  bgClone: Clutter.Actor;
   windowsContainer: Clutter.Actor;
   clones: Map<Meta.WindowActor, Clutter.Actor>;
   effect: LiquidEffect;
   // Unblurred base background, used to reveal the true corners (see InverseCornerEffect below).
   baseActor: St.Widget;
-  baseClone: InstanceType<typeof UnpickableClone>;
+  baseClone: Clutter.Actor;
   baseWindowsContainer: Clutter.Actor;
   baseClones: Map<Meta.WindowActor, Clutter.Actor>;
   // To cut window corners
@@ -41,6 +41,9 @@ interface WindowState {
   // Content opacity applied to the window's own surface layer so the glass shows
   // through it; restored when the effect is removed from this window.
   originalOpacity: number;
+  // [Debug] Signature of the last _syncState outcome; used to only log state
+  // transitions (not every 60fps frame).
+  _lastSyncLog?: string;
 }
 
 export class ApplicationManager {
@@ -293,6 +296,34 @@ export class ApplicationManager {
     return SHADER_PADDING;
   }
 
+  // ─── [Debug] helpers ──────────────────────────────────────────────────────
+
+  private _winTitle(state: WindowState): string {
+    try {
+      const meta = state.windowActor?.get_meta_window?.();
+      return meta?.get_title?.() ?? state.windowActor?.get_name?.() ?? '?';
+    } catch (e) {
+      return '?';
+    }
+  }
+
+  private _winTitleOfActor(windowActor: Meta.WindowActor): string {
+    try {
+      const meta = windowActor?.get_meta_window?.();
+      return meta?.get_title?.() ?? windowActor?.get_name?.() ?? '?';
+    } catch (e) {
+      return '?';
+    }
+  }
+
+  // _syncState runs every frame; log only when the outcome changes so
+  // journalctl isn't flooded at 60fps.
+  private _debugSync(state: WindowState, msg: string): void {
+    if (state._lastSyncLog === msg) return;
+    state._lastSyncLog = msg;
+    this._logger.log(`[Liquid Glass][Debug] _syncState["${this._winTitle(state)}"]: ${msg}`);
+  }
+
   _startFrameSync() {
     if (this._frameSyncId === 0)
       this._frameTick();
@@ -339,16 +370,20 @@ export class ApplicationManager {
     if (!parent)
       return;
 
+    this._logger.log(`[Liquid Glass][Debug] _setupWindow: setting up glass for window "${this._winTitleOfActor(windowActor)}", ` +
+      `surface="${surfaceActor.get_name?.() ?? surfaceActor.constructor.name}", parent="${parent.get_name?.() ?? parent.constructor.name}"`);
+
     // Store the surface's original opacity and dial it down so the glass behind
     // it is actually visible; restored in _cleanupState when the effect is removed.
     let originalOpacity = surfaceActor.opacity;
     surfaceActor.opacity = Math.round(this._getContentOpacity() * 255);
+    this._logger.log(`[Liquid Glass][Debug] _setupWindow: surface opacity ${originalOpacity} -> ${surfaceActor.opacity}`);
 
     let baseActor = new St.Widget({
       style_class: 'liquid-glass-base-actor',
       reactive: false,
       clip_to_allocation: true,
-      visible: true,
+      visible: false,
     });
     windowActor.insert_child_below(baseActor, surfaceActor);
 
@@ -356,7 +391,7 @@ export class ApplicationManager {
       style_class: 'liquid-glass-bg-actor',
       reactive: false,
       clip_to_allocation: false,
-      visible: true,
+      visible: false,
     });
     windowActor.insert_child_above(bgActor, baseActor);
 
@@ -382,9 +417,11 @@ export class ApplicationManager {
     // Size the clones to cover the full monitor so the wallpaper fills correctly.
     let monitor = Main.layoutManager.primaryMonitor;
 
-    let baseClone = new UnpickableClone({
-      source: Main.layoutManager._backgroundGroup,
-    });
+    // Wallpaper-only sampler: cloning _backgroundGroup as a whole is unsafe
+    // with PaperWM active (PaperWM nests its window clones inside it, which
+    // closes an infinite paint-recursion through the glass chrome →
+    // _backgroundGroup → PaperWM window clone → window chrome → ...).
+    let baseClone: Clutter.Actor = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
     if (monitor) {
       baseClone.set_size(monitor.width, monitor.height);
     }
@@ -393,9 +430,7 @@ export class ApplicationManager {
     let baseWindowsContainer = new Clutter.Actor();
     baseActor.add_child(baseWindowsContainer);
 
-    let bgClone = new UnpickableClone({
-      source: Main.layoutManager._backgroundGroup,
-    });
+    let bgClone: Clutter.Actor = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
     if (monitor) {
       bgClone.set_size(monitor.width, monitor.height);
     }
@@ -446,6 +481,7 @@ export class ApplicationManager {
     let cornerOverlay = new UnpickableActor({
       clip_to_allocation: true,
       reactive: false,
+      visible: false,
     });
     let cornerOverlayClone = new UnpickableClone({ source: baseActor });
     cornerOverlay.add_child(cornerOverlayClone);
@@ -478,6 +514,10 @@ export class ApplicationManager {
     };
 
     this._states.set(windowActor, state);
+    this._logger.log(`[Liquid Glass][Debug] _setupWindow: state registered for "${this._winTitleOfActor(windowActor)}", ` +
+      `bgActor="${state.bgActor.get_name?.() ?? state.bgActor.constructor.name}", ` +
+      `baseActor="${state.baseActor.get_name?.() ?? state.baseActor.constructor.name}"`);
+
     this._rebuildWindowClones(state);
 
     // Immediate sync connections for resize/move using allocation property
@@ -506,6 +546,7 @@ export class ApplicationManager {
     // Use a later to ensure the initial sync happens after actors are properly added to stage
     global.compositor.get_laters().add(Meta.LaterType.IDLE, () => {
       if (this._states.has(windowActor)) {
+        this._logger.log(`[Liquid Glass][Debug] _setupWindow: IDLE initial sync for "${this._winTitle(state)}"`);
         this._syncState(state);
       }
       return false;
@@ -553,11 +594,15 @@ export class ApplicationManager {
       state.baseWindowsContainer.add_child(baseClone);
       state.baseClones.set(actor, baseClone);
     }
+
+    this._logger.log(`[Liquid Glass][Debug] _rebuildWindowClones["${this._winTitle(state)}"]: ` +
+      `${state.clones.size} blurred clones, ${state.baseClones.size} base clones`);
   }
 
   _syncState(state: WindowState) {
     let actor = state.windowActor;
     if (!actor || !actor.get_stage() || !actor.mapped) {
+      this._debugSync(state, 'window not mapped / off-stage; glass hidden');
       state.bgActor.visible = false;
       state.baseActor.visible = false;
       state.cornerOverlay.visible = false;
@@ -565,17 +610,28 @@ export class ApplicationManager {
     }
 
     if (!actor.has_allocation()) {
+      this._debugSync(state, 'no allocation yet; glass hidden');
+      state.bgActor.visible = false;
+      state.baseActor.visible = false;
+      state.cornerOverlay.visible = false;
       return;
     }
 
     const metaWin = actor.get_meta_window();
-    if (!metaWin) return;
+    if (!metaWin) {
+      this._debugSync(state, 'no meta-window; glass hidden');
+      state.bgActor.visible = false;
+      state.baseActor.visible = false;
+      state.cornerOverlay.visible = false;
+      return;
+    }
 
     // PERFORMANCE: Only sync windows on the current active workspace.
     const workspaceManager = global.workspace_manager;
     const activeWorkspace = workspaceManager.get_active_workspace();
     const winWorkspace = metaWin.get_workspace();
     if (winWorkspace && winWorkspace !== activeWorkspace) {
+      this._debugSync(state, 'not on active workspace; glass hidden');
       if (state.bgActor.visible) state.bgActor.visible = false;
       if (state.baseActor.visible) state.baseActor.visible = false;
       if (state.cornerOverlay.visible) state.cornerOverlay.visible = false;
@@ -586,14 +642,27 @@ export class ApplicationManager {
     const bufferRect = metaWin.get_buffer_rect();
 
     if (!rect || !bufferRect || rect.width <= 0 || rect.height <= 0) {
+      this._debugSync(state, `invalid frame rect (${rect?.x},${rect?.y} ${rect?.width}x${rect?.height}); glass hidden`);
       if (state.bgActor.visible) state.bgActor.visible = false;
       if (state.baseActor.visible) state.baseActor.visible = false;
       if (state.cornerOverlay.visible) state.cornerOverlay.visible = false;
       return;
     }
 
+    this._debugSync(state,
+      `showing glass: frame=(${rect.x},${rect.y} ${rect.width}x${rect.height}) ` +
+      `buffer=(${bufferRect.x},${bufferRect.y} ${bufferRect.width}x${bufferRect.height}) ` +
+      `bg=${rect.width + (SHADER_PADDING * 2)}x${rect.height + (SHADER_PADDING * 2)} ` +
+      `base=${rect.width + (SHADER_PADDING * 2)}x${rect.height + (SHADER_PADDING * 2)} ` +
+      `clones=${state.clones.size}/${state.baseClones.size} surfaceOpacity=${state.surfaceActor.opacity}`);
+
     if (!state.bgActor.visible) state.bgActor.visible = true;
     if (!state.baseActor.visible) state.baseActor.visible = true;
+
+    // Rebuild the wallpaper samplers in place if the wallpaper actors were
+    // swapped (wallpaper/monitor changes). Cheap identity check per frame.
+    refreshWallpaperSampler(state.bgClone);
+    refreshWallpaperSampler(state.baseClone);
 
     // Local offset of the visible frame within the window actor's full buffer.
     const frameLocalX = rect.x - bufferRect.x;
@@ -706,6 +775,9 @@ export class ApplicationManager {
 
   _cleanupState(state: WindowState) {
     if (!state) return;
+
+    this._logger.log(`[Liquid Glass][Debug] _cleanupState["${this._winTitle(state)}"]: removing glass, ` +
+      `restoring surface opacity ${state.surfaceActor?.opacity} -> ${state.originalOpacity}`);
 
     // Restore the original opacity of the window's own content layer.
     // Uses the cached surfaceActor reference (see WindowState) rather than

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/liquidEffect.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/liquidEffect.ts
@@ -198,6 +198,10 @@ export const LiquidEffect = GObject.registerClass({
   declare private _diagLastPaintLogAt: number;
   declare private _diagFirstPaintLogged: boolean;
 
+  // ── [Debug] change-detection for per-frame paint/sync logging ──
+  declare private _lastPaintSig: string | null;
+  declare private _lastCropLog: string | null;
+
   // ─── _init ──────────────────────────────────────────────────────────────────
 
   _init(params: LiquidEffectParams) {
@@ -250,6 +254,8 @@ export const LiquidEffect = GObject.registerClass({
     this._diagCompositedPaintCount = 0;
     this._diagLastPaintLogAt = 0;
     this._diagFirstPaintLogged = false;
+    this._lastPaintSig = null;
+    this._lastCropLog = null;
 
     this._extensionPath = extensionPath;
     this._settings = settings;
@@ -433,6 +439,10 @@ export const LiquidEffect = GObject.registerClass({
 
     // Apply any uniforms that were buffered before the pipeline existed.
     this._applyPendingUniforms();
+
+    this._logger?.log(`[Liquid Glass][Debug] _initPipelines: pipelines compiled ` +
+      `(composite=${!!this._compositePipeline}, down=${!!this._downsamplePipeline}, ` +
+      `up=${!!this._upsamplePipeline}, gaussian=${!!this._gaussianHPipeline && !!this._gaussianVPipeline})`);
   }
 
   /**
@@ -648,6 +658,10 @@ export const LiquidEffect = GObject.registerClass({
 
     this._poolWidth = w;
     this._poolHeight = h;
+
+    this._logger?.log(`[Liquid Glass][Debug] _buildTexturePool: ${this.PASS_COUNT} passes built for ${w}x${h} ` +
+      `(top level ${this._blurTextures[0]?.get_width?.() ?? '?'}x${this._blurTextures[0]?.get_height?.() ?? '?'}, ` +
+      `textures=${this._blurTextures.length}, gaussianTemp=${this._gaussianTempTextures.length})`);
   }
 
   /**
@@ -816,6 +830,12 @@ export const LiquidEffect = GObject.registerClass({
    * one if the size hasn't changed.
    */
   private _ensureCropTarget(ctx: Cogl.Context, w: number, h: number): boolean {
+    // Never create a 0-size texture: Cogl asserts width/height >= 1 and returns
+    // NULL otherwise (cogl_texture_2d_new_with_size: assertion 'width >= 1'
+    // failed), and the resulting NULL texture would crash Offscreen.new_with_texture.
+    w = Math.max(Math.round(w), 1);
+    h = Math.max(Math.round(h), 1);
+
     if (this._cropTexture && this._cropFbo &&
       this._cropPoolW === w && this._cropPoolH === h) {
       return true;
@@ -835,6 +855,7 @@ export const LiquidEffect = GObject.registerClass({
       this._cropFbo = fbo;
       this._cropPoolW = w;
       this._cropPoolH = h;
+      this._logger?.log(`[Liquid Glass][Debug] _ensureCropTarget: created crop texture ${w}x${h}`);
       return true;
     } catch (e) {
       this._logger?.error(`[Liquid Glass] Failed to create crop texture (${w}x${h}): ${e}`);
@@ -1019,6 +1040,21 @@ export const LiquidEffect = GObject.registerClass({
       if (Number.isFinite(ah) && ah > 0) allocH = Math.round(ah);
     }
 
+    // [Debug] Log the per-frame paint geometry, but only when it changes so
+    // journalctl isn't flooded at 60fps.
+    {
+      let actorName = '?';
+      try { actorName = (actor?.get_name?.() ?? actor?.constructor?.name ?? '?') as string; } catch (e) { }
+      const paintSig =
+        `src=${srcW}x${srcH} alloc=${allocW}x${allocH} ` +
+        `cropPool=${this._cropPoolW}x${this._cropPoolH} pool=${this._poolWidth}x${this._poolHeight} ` +
+        `blurMethod=${this._blurMethod} passCount=${this.PASS_COUNT} shadersLoaded=${this._shadersLoaded}`;
+      if (this._lastPaintSig !== paintSig) {
+        this._lastPaintSig = paintSig;
+        this._logger?.log(`[Liquid Glass][Debug] vfunc_paint_target["${actorName}"]: ${paintSig}`);
+      }
+    }
+
     // ── Only run the crop pass when padding is actually present ─────────────
     // (When sizes match, _cropSourceTexture just returns srcTex unchanged,
     //  so the normal-case overhead is a single size comparison.)
@@ -1037,6 +1073,11 @@ export const LiquidEffect = GObject.registerClass({
         if (effectiveTex !== srcTex) {
           effectiveW = allocW;
           effectiveH = allocH;
+          const cropLog = `${srcW}x${srcH}->${allocW}x${allocH}`;
+          if (this._lastCropLog !== cropLog) {
+            this._lastCropLog = cropLog;
+            this._logger?.log(`[Liquid Glass][Debug] crop applied: ${cropLog}`);
+          }
         }
       } catch (e) {
         this._logger?.error(`[Liquid Glass] Crop pass failed; continuing with the padded texture: ${e}`);

--- a/liquid-glass@thinkingcoding1231.gmail.com/src/utils.ts
+++ b/liquid-glass@thinkingcoding1231.gmail.com/src/utils.ts
@@ -8,6 +8,7 @@
 import GObject from 'gi://GObject';
 import Clutter from 'gi://Clutter';
 import Cogl from 'gi://Cogl';
+import Meta from 'gi://Meta';
 import * as Main from 'resource:///org/gnome/shell/ui/main.js';
 import St from 'gi://St';
 import Mtk from 'gi://Mtk';
@@ -221,6 +222,81 @@ export const UnpickableWidget = GObject.registerClass(
     }
   }
 );
+
+/**
+ * Returns an actor that renders just the wallpaper — the Meta.BackgroundActor
+ * children of `Main.layoutManager._backgroundGroup` — positioned exactly as a
+ * whole-group clone would be. Returns null if the group or its background
+ * actors are unavailable, in which case callers fall back to cloning the group.
+ *
+ * WHY NOT clone `_backgroundGroup` directly: extensions such as PaperWM
+ * reparent their window-clone trees into it (PaperWM's tiling.js does
+ * `backgroundGroup.add_child(spaceContainer)`, and `spaceContainer` holds a
+ * `Clutter.Clone` of every window actor). Cloning the group then closes an
+ * infinite paint-recursion once a Liquid Glass window is visible:
+ *
+ *     bgClone → _backgroundGroup → PaperWM window clone → window actor →
+ *     glass chrome (cornerOverlay/baseActor) → bgClone → ...
+ *
+ * Each cycle re-paints the same actors forever → stack overflow / SEGV.
+ * Sampling only the Meta.BackgroundActor children keeps the wallpaper while
+ * excluding every extension-added subtree, so the loop can never close.
+ */
+function _wallpaperBackgroundActors(): Clutter.Actor[] {
+  const bgGroup = Main.layoutManager._backgroundGroup as unknown as Clutter.Actor | null;
+  if (!bgGroup) return [];
+  try {
+    return (bgGroup.get_children() ?? []).filter(c => c instanceof Meta.BackgroundActor);
+  } catch (_) {
+    return [];
+  }
+}
+
+function _rebuildWallpaperSamplerClones(sampler: Clutter.Actor): void {
+  const wallpapers = _wallpaperBackgroundActors();
+  (sampler as any)._wallpaperSources = wallpapers;
+  try {
+    sampler.remove_all_children();
+  } catch (_) {
+    return;
+  }
+  for (const wp of wallpapers) {
+    const clone = new UnpickableClone({ source: wp });
+    try { clone.set_size(wp.get_width(), wp.get_height()); } catch (_) { }
+    try { sampler.add_child(clone); } catch (_) { }
+  }
+}
+
+/**
+ * Creates a wallpaper sampler sized like the background group. The returned
+ * actor is a plain container (not a Clutter.Clone), so callers keep using
+ * set_position()/set_size() exactly as they did with the old whole-group clone.
+ */
+export function createWallpaperSampler(): Clutter.Actor | null {
+  const bgGroup = Main.layoutManager._backgroundGroup as unknown as Clutter.Actor | null;
+  if (!bgGroup) return null;
+  if (_wallpaperBackgroundActors().length === 0) return null;
+
+  const sampler = new UnpickableActor();
+  (sampler as any)._isWallpaperSampler = true;
+  try { sampler.set_size(bgGroup.get_width(), bgGroup.get_height()); } catch (_) { }
+  _rebuildWallpaperSamplerClones(sampler);
+  return sampler;
+}
+
+/**
+ * Rebuilds a wallpaper sampler's clones in place if the set of wallpaper
+ * actors changed (wallpaper changes swap Meta.BackgroundActor instances).
+ * Cheap: compares the stored source list each call; rebuilds only on change.
+ * No-op for actors that were not created by createWallpaperSampler().
+ */
+export function refreshWallpaperSampler(sampler: Clutter.Actor | null): void {
+  if (!sampler || !(sampler as any)._isWallpaperSampler) return;
+  const cur = (sampler as any)._wallpaperSources as Clutter.Actor[] | null;
+  const wallpapers = _wallpaperBackgroundActors();
+  if (cur && cur.length === wallpapers.length && cur.every((a, i) => a === wallpapers[i])) return;
+  _rebuildWallpaperSamplerClones(sampler);
+}
 
 /**
  * Paints a captured texture stretched to fill its own allocation, without
@@ -856,7 +932,7 @@ export class UILayerSampler {
 export class WindowCloneManager {
   private windowClonesContainer: Clutter.Actor | null = null;
   private _windowClones: Map<Clutter.Actor, Clutter.Clone>;
-  private bgClone: Clutter.Clone | null = null;
+  private bgClone: Clutter.Actor | null = null;
 
   private container: Clutter.Actor | null = null;
   private cloneContainer: Clutter.Actor | null = null;
@@ -865,7 +941,10 @@ export class WindowCloneManager {
     this.container = container;
     this._windowClones = new Map();
 
-    this.bgClone = new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
+    // Wallpaper-only sampler: cloning _backgroundGroup as a whole is unsafe
+    // with PaperWM active (PaperWM nests window clones inside it, which
+    // closes an infinite paint-recursion through visible glass chrome).
+    this.bgClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
     this.bgClone.connect('destroy', () => { this.bgClone = null; });
 
     this.windowClonesContainer = new UnpickableActor();
@@ -893,7 +972,7 @@ export class WindowCloneManager {
     if (this.bgClone) { this.bgClone.destroy(); }
     if (this.windowClonesContainer) { this.windowClonesContainer.destroy(); }
 
-    this.bgClone = new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
+    this.bgClone = createWallpaperSampler() ?? new UnpickableClone({ source: Main.layoutManager._backgroundGroup });
     this.bgClone.connect('destroy', () => { this.bgClone = null; });
 
     this.windowClonesContainer = new UnpickableActor();


### PR DESCRIPTION
Again, good work, guys on merging window effect feature into the main branch. I really appreciate your guys' effort.

I found some bugs while testing the new implementation since my environment has another gnome extension called PaperWM enabled. However, I've found the root cause and implemented a fix on it. It seems to be caused by the corner overlay implementation.

